### PR TITLE
Remove AutoLazy reference after processing

### DIFF
--- a/src/AutoLazy.Fody/LazyVisitor.cs
+++ b/src/AutoLazy.Fody/LazyVisitor.cs
@@ -8,25 +8,34 @@ namespace AutoLazy.Fody
     {
         public void Visit(MethodDefinition method, VisitorContext context)
         {
-            if (IsLazy(method))
+            var lazyAttribute = GetLazyAttribute(method);
+            if (lazyAttribute != null)
             {
                 var instrumentor = new DoubleCheckedLockingWeaver(method, context);
                 instrumentor.Instrument();
+                method.CustomAttributes.Remove(lazyAttribute);
             }
         }
 
         public void Visit(PropertyDefinition property, VisitorContext context)
         {
-            if (IsLazy(property) && property.GetMethod != null && !IsLazy(property.GetMethod))
+            var lazyAttribute = GetLazyAttribute(property);
+            if (lazyAttribute != null && property.GetMethod != null && !IsLazy(property.GetMethod))
             {
                 var instrumentor = new DoubleCheckedLockingWeaver(property.GetMethod, context);
                 instrumentor.Instrument();
+                property.CustomAttributes.Remove(lazyAttribute);
             }
         }
 
         private bool IsLazy(ICustomAttributeProvider target)
         {
             return target.HasCustomAttributes && target.CustomAttributes.Any(a => a.AttributeType.FullName == "AutoLazy.LazyAttribute");
+        }
+
+        private CustomAttribute GetLazyAttribute(ICustomAttributeProvider target)
+        {
+            return target.HasCustomAttributes ? target.CustomAttributes.FirstOrDefault(a => a.AttributeType.FullName == "AutoLazy.LazyAttribute") : null;
         }
     }
 }

--- a/src/AutoLazy.Fody/ModuleWeaver.cs
+++ b/src/AutoLazy.Fody/ModuleWeaver.cs
@@ -22,6 +22,7 @@ namespace AutoLazy.Fody
             var context = new VisitorContext(this);
             VisitProperties(context);
             VisitMethods(context);
+            VisitAssemblyReferences(context);
         }
 
         private void VisitProperties(VisitorContext context)
@@ -52,6 +53,23 @@ namespace AutoLazy.Fody
                     visitor.Visit(method, context);
                 }
             }
+        }
+
+        private void VisitAssemblyReferences(VisitorContext context)
+        {
+            // Attempt to locate the "AutoLazy" assembly reference.
+            var assemblyName = ModuleDefinition.AssemblyReferences.FirstOrDefault(
+                reference => reference.FullName.StartsWith("AutoLazy")
+            );
+
+            // Verify our result.
+            if(assemblyName == null) {
+                // Will happen if AutoLazy is added, but not used.
+                return;
+            }
+
+            // Remove unnecessary references remaining in our subject assembly.
+            ModuleDefinition.AssemblyReferences.Remove(assemblyName);
         }
 
         private T[] GetImplementations<T>()

--- a/src/nuget/AutoLazy.nuspec
+++ b/src/nuget/AutoLazy.nuspec
@@ -6,6 +6,7 @@
     <title>AutoLazy.Fody</title>
     <authors>Brandon Cuff</authors>
     <owners>Brandon Cuff</owners>
+    <developmentDependency>true</developmentDependency>
     <licenseUrl>https://github.com/bcuff/AutoLazy/blob/master/LICENSE.md</licenseUrl>
     <projectUrl>http://github.com/bcuff/AutoLazy</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/src/nuget/tools/net40/install.ps1
+++ b/src/nuget/tools/net40/install.ps1
@@ -66,7 +66,6 @@ function Fix-ReferencesCopyLocal($package, $project)
     {
         if ($asms -contains $reference.Name + ".dll")
         {
-            if($reference.Name -eq "AutoLazy") { continue }
             if($reference.CopyLocal -eq $true)
             {
                 $reference.CopyLocal = $false;


### PR DESCRIPTION
I'm not sure what your plans are for the `KeyedLazy` stuff, so this might not fit, but I figured I'd off these changes nonetheless. Just a few small updates to remove the `AutoLazy.Lazy` attributes and `AutoLazy.dll` reference after processing. Nuget package and install script were updated accordingly.